### PR TITLE
Allow CarComponent to be in children

### DIFF
--- a/Assets/Scenes/IntroScene.unity
+++ b/Assets/Scenes/IntroScene.unity
@@ -838,6 +838,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 7629395629189959507, guid: 75df3232efe28194392520097ea6e773, type: 3}
   m_PrefabInstance: {fileID: 351812846}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &363515981 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3672715291799903472, guid: d0ea3f39cebb2f00aab40edc93fe4e13, type: 3}
+  m_PrefabInstance: {fileID: 2131259607}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &439562158
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -981,11 +986,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: be28c55f780729140b0943c8f2e37599, type: 3}
---- !u!1 &457179050 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 8746654869797669059, guid: d0ea3f39cebb2f00aab40edc93fe4e13, type: 3}
-  m_PrefabInstance: {fileID: 2131259607}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &484644204
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2078,18 +2078,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   situations:
-  - car: {fileID: 457179050}
+  - car: {fileID: 363515981}
     waypoint: {fileID: 336862658}
   - car: {fileID: 1439625876}
     waypoint: {fileID: 2126707191}
   - car: {fileID: 936698756}
     waypoint: {fileID: 928191721}
-  - car: {fileID: 20448096}
-    waypoint: {fileID: 1360610154}
   - car: {fileID: 1153750934}
     waypoint: {fileID: 1402620872}
   - car: {fileID: 1942532676}
     waypoint: {fileID: 1250691579}
+  - car: {fileID: 20448096}
+    waypoint: {fileID: 1360610154}
 --- !u!1001 &1153750933
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/CarController.cs
+++ b/Assets/Scripts/CarController.cs
@@ -139,4 +139,15 @@ public class CarController : MonoBehaviour, IInputReceiver
         Vector2 engineForce = transform.up * (_accelerationInput * accelerationSpeed);
         _rb.AddForce(engineForce, ForceMode2D.Force);
     }
+    
+    public static CarController GetCarController(GameObject carParent)
+    {
+        var carController = carParent.GetComponent<CarController>();
+        if (!carController)
+            carController = carParent.GetComponentInChildren<CarController>();
+        if (!carController)
+            throw new UnityException("No CarController found");
+        
+        return carController;
+    }
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -34,7 +34,7 @@ public class GameManager : MonoBehaviour
         var activeCar = ActiveCar();
         var nextCar = _situationGenerator.GenerateSituation(NextSituation, NextLevel);
         var oldPath = deepCopy(_recorder.StopRecording());
-        _recorder.StartRecording(nextCar.GetComponent<CarController>());
+        _recorder.StartRecording(CarController.GetCarController(nextCar));
         _pathIndex = 0;
         
         if (!activeCar) return; // first car

--- a/Assets/Scripts/WaypointBehaviour.cs
+++ b/Assets/Scripts/WaypointBehaviour.cs
@@ -14,7 +14,7 @@ public class WaypointBehaviour : MonoBehaviour
     {
         if (_deactivated) return;
         
-        var carController = other.gameObject.GetComponent<CarController>();
+        var carController = CarController.GetCarController(other.gameObject);
         if (!carController || !carController.IsDrivenByPlayer()) return;
         
         OnWaypointReached.Invoke();


### PR DESCRIPTION
Resolves #23 

Added static function to abstract `CarComponent` access. This allows the `CarComponent` to be in children of a gameobject to allow easier grouping of e.g. semitrucks